### PR TITLE
fix(aerospace): use correct config value

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
   };
 
   outputs = inputs @ {
+    self,
     nixpkgs,
     unstable,
     nix-darwin,
@@ -63,6 +64,12 @@
       home-manager.extraSpecialArgs = cfg // {inherit inputs;};
     };
   in {
+
+    checks = {
+      x86_64-linux.NixOS = self.nixosConfigurations.NixOS.config.system.build.toplevel;
+      aarch64-darwin.MacOS = self.darwinConfigurations.MacOS.system;
+    };
+
     nixosConfigurations.NixOS = nixpkgs.lib.nixosSystem {
       system = personalSettings.system;
       specialArgs = personalSettings;

--- a/home-manager/modules/MacOS/aerospace.nix
+++ b/home-manager/modules/MacOS/aerospace.nix
@@ -15,7 +15,7 @@
     };
   };
 
-  g = gaps.${config.iamkarasik.aerospace};
+  g = gaps.${config.iamkarasik.aerospace.gapSize};
 in {
   options.iamkarasik.aerospace.gapSize = lib.mkOption {
     type = lib.types.enum ["small" "big"];


### PR DESCRIPTION
# Description
The wrong path was being used to get the gap size in aerospace